### PR TITLE
Change CircleCI badge style to "shield"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![AutoGraph](https://github.com/remind101/AutoGraph/blob/master/autograph.png)](https://github.com/remind101/AutoGraph/blob/master/autograph.png)
 
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/AutoGraph.svg)](https://img.shields.io/cocoapods/v/AutoGraph.svg)
-[![CircleCI](https://circleci.com/gh/remind101/AutoGraph.svg?style=svg&circle-token=3e12fea283d6d6476e480f1cc77e9b14a63e5487)](https://circleci.com/gh/remind101/AutoGraph)
+[![CircleCI](https://circleci.com/gh/remind101/AutoGraph.svg?style=shield&circle-token=3e12fea283d6d6476e480f1cc77e9b14a63e5487)](https://circleci.com/gh/remind101/AutoGraph)
 
 The Swiftest way to GraphQL
 


### PR DESCRIPTION
Just for some style consistency with the CocoaPods shield.

![](http://ejholmes.github.com.s3.amazonaws.com/sohNMzz5RWBd9VUk3DHHeiZ8iX5uQ3MTXV.png)

vs

![](http://ejholmes.github.com.s3.amazonaws.com/ykMbSbxp62EvaMQiJ8QkVPF15PSeZliFTN.png)