### PR TITLE
Query builder cleanup

### DIFF
--- a/QueryBuilder/FoundationExtensions.swift
+++ b/QueryBuilder/FoundationExtensions.swift
@@ -4,6 +4,7 @@ import JSONValueRX
 enum QueryBuilderError: LocalizedError {
     case incorrectArgumentKey(key: Any)
     case incorrectArgumentValue(value: Any)
+    case missingFields(selectionSetName: String)
     
     public var errorDescription: String? {
         switch self {
@@ -11,6 +12,8 @@ enum QueryBuilderError: LocalizedError {
             return "value \(value) is not an `InputValue`"
         case .incorrectArgumentKey(let key):
             return "key \(key) is not a `String`"
+        case .missingFields(selectionSetName: let selectionSetName):
+            return "Selection Set on \(selectionSetName) must have either `fields` or `fragments` or both"
         }
     }
 }

--- a/QueryBuilder/FoundationExtensions.swift
+++ b/QueryBuilder/FoundationExtensions.swift
@@ -22,6 +22,10 @@ extension String: Field, InputValue, GraphQLQuery {
     public var alias: String? {
         return nil
     }
+    
+    public var directives: [Directive]? {
+        return nil
+    }
 
     public func graphQLString() throws -> String {
         return self.name

--- a/QueryBuilder/QueryDSL.swift
+++ b/QueryBuilder/QueryDSL.swift
@@ -70,6 +70,7 @@ public struct Fragment: AcceptsSelectionSet, QueryConvertible {
 /// This type must accept `Field`s and `Fragment`s and must include either a set of
 /// `fragments` _(FragmentSpread)_ or a set of `fields` or both.
 public protocol AcceptsSelectionSet: AcceptsFields {
+    var name: String { get }
     var fields: [Field]? { get }
     var fragments: [Fragment]? { get }
     func serializedFragments() throws -> String
@@ -88,7 +89,7 @@ public extension AcceptsSelectionSet {
         }.joined(separator: "\n")
         
         guard selectionSet.characters.count > 0 else {
-            return ""
+            throw QueryBuilderError.missingFields(selectionSetName: self.name)
         }
         
         return " {\n\(selectionSet)\n}"

--- a/QueryBuilder/QueryDSL.swift
+++ b/QueryBuilder/QueryDSL.swift
@@ -195,7 +195,7 @@ public struct Object: Field, AcceptsArguments, AcceptsSelectionSet, AcceptsDirec
     }
 }
 
-/// Defines an _Directive_ from the GraphQL language.
+/// Defines a _Directive_ from the GraphQL language.
 public struct Directive: AcceptsArguments, QueryConvertible {
     public let name: String
     public let arguments: [String : InputValue]?

--- a/QueryBuilderTests/QueryBuilderTests.swift
+++ b/QueryBuilderTests/QueryBuilderTests.swift
@@ -4,9 +4,12 @@ import XCTest
 class FieldTests: XCTestCase {
     
     class FieldMock: Field {
+        var directives: [Directive]?
+
         var name: String {
             return "mock"
         }
+        
         var alias: String?
         func graphQLString() throws -> String {
             return "blah"
@@ -52,6 +55,19 @@ class AcceptsFieldsTests: XCTestCase {
         self.subject.fields = [ scalar1, object ]
         XCTAssertEqual(try! self.subject.serializedFields(), "scalar1\ncool: obj(key: \"value\") {\nderp: scalar2\n}")
     }
+    
+    func testSerializedFieldsWithDirectives() {
+        XCTAssertEqual(try! self.subject.serializedFields(), "")
+        
+        let directive1 = Directive(name: "cool", arguments: ["best" : "directive"])
+        let scalar1 = Scalar(name: "scalar1", alias: nil, directives: [directive1])
+        let scalar2 = Scalar(name: "scalar2", alias: "derp")
+        let objDirective = Directive(name: "obj", arguments: ["best" : "objDirective"])
+        let object = Object(name: "obj", alias: "cool", fields: [scalar2], fragments: nil, arguments: ["key" : "value"], directives: [objDirective])
+        
+        self.subject.fields = [ scalar1, object ]
+        XCTAssertEqual(try! self.subject.serializedFields(), "scalar1 @cool(best: \"directive\")\ncool: obj(key: \"value\") @obj(best: \"objDirective\") {\nderp: scalar2\n}")
+    }
 }
 
 class ScalarTests: XCTestCase {
@@ -77,14 +93,19 @@ class ObjectTests: XCTestCase {
     
     var subject: Object!
     
+    func testThrowsIfNoFieldsOrFragments() {
+        self.subject = Object(name: "obj", alias: "cool_alias")
+        XCTAssertThrowsError(try self.subject.graphQLString())
+    }
+    
     func testGraphQLStringWithAlias() {
-        self.subject = Object(name: "obj", alias: "cool_alias", fields: nil, fragments: nil, arguments: nil)
-        XCTAssertEqual(try! self.subject.graphQLString(), "cool_alias: obj")
+        self.subject = Object(name: "obj", alias: "cool_alias", fields: ["scalar"], fragments: nil, arguments: nil)
+        XCTAssertEqual(try! self.subject.graphQLString(), "cool_alias: obj {\nscalar\n}")
     }
     
     func testGraphQLStringWithoutAlias() {
-        self.subject = Object(name: "obj", alias: nil, fields: nil, fragments: nil, arguments: nil)
-        XCTAssertEqual(try! self.subject.graphQLString(), "obj")
+        self.subject = Object(name: "obj", alias: nil, fields: ["scalar"], fragments: nil, arguments: nil)
+        XCTAssertEqual(try! self.subject.graphQLString(), "obj {\nscalar\n}")
     }
     
     func testGraphQLStringWithScalarFields() {
@@ -105,17 +126,17 @@ class ObjectTests: XCTestCase {
     }
 }
 
-class FragmentTests: XCTestCase {
-    var subject: Fragment!
+class FragmentDefinitionTests: XCTestCase {
+    var subject: FragmentDefinition!
     
     func testWithoutSelectionSetIsNil() {
-        self.subject = Fragment(name: "frag", type: "CoolType", fields: nil, fragments: nil)
+        self.subject = FragmentDefinition(name: "frag", type: "CoolType", fields: nil, fragments: nil)
         XCTAssertNil(self.subject)
     }
     
     func testFragmentNamedOnIsNil() {
         let scalar1 = Scalar(name: "scalar1", alias: "cool_scalar")
-        self.subject = Fragment(name: "on", type: "CoolType", fields: [scalar1], fragments: nil)
+        self.subject = FragmentDefinition(name: "on", type: "CoolType", fields: [scalar1], fragments: nil)
         XCTAssertNil(self.subject)
     }
     
@@ -123,7 +144,7 @@ class FragmentTests: XCTestCase {
         let scalar1 = Scalar(name: "scalar1", alias: "cool_scalar")
         let scalar2 = Scalar(name: "scalar2", alias: nil)
         
-        self.subject = Fragment(name: "frag", type: "CoolType", fields: [scalar1, scalar2], fragments: nil)
+        self.subject = FragmentDefinition(name: "frag", type: "CoolType", fields: [scalar1, scalar2], fragments: nil)
         XCTAssertEqual(try! self.subject.graphQLString(), "fragment frag on CoolType {\ncool_scalar: scalar1\nscalar2\n}")
     }
     
@@ -132,18 +153,27 @@ class FragmentTests: XCTestCase {
         let scalar2 = Scalar(name: "scalar2", alias: nil)
         let subobj = Object(name: "subobj", alias: "cool_obj", fields: [scalar1], fragments: nil, arguments: nil)
         
-        self.subject = Fragment(name: "frag", type: "CoolType", fields: [subobj, scalar2], fragments: nil)
+        self.subject = FragmentDefinition(name: "frag", type: "CoolType", fields: [subobj, scalar2], fragments: nil)
         XCTAssertEqual(try! self.subject.graphQLString(), "fragment frag on CoolType {\ncool_obj: subobj {\ncool_scalar: scalar1\n}\nscalar2\n}")
     }
     
     func testGraphQLStringWithFragments() {
         let scalar1 = Scalar(name: "scalar1", alias: "cool_scalar")
-        let fragment1 = Fragment(name: "frag1", type: "Fraggie", fields: [scalar1], fragments: nil)!
+        let fragment1 = FragmentDefinition(name: "frag1", type: "Fraggie", fields: [scalar1], fragments: nil)!
         let scalar2 = Scalar(name: "scalar2", alias: nil)
-        let fragment2 = Fragment(name: "frag2", type: "Freggie", fields: [scalar2], fragments: nil)!
+        let fragment2 = FragmentDefinition(name: "frag2", type: "Freggie", fields: [scalar2], fragments: nil)!
         
-        self.subject = Fragment(name: "frag", type: "CoolType", fields: nil, fragments: [fragment1, fragment2])
+        self.subject = FragmentDefinition(name: "frag", type: "CoolType", fields: nil, fragments: [FragmentSpread(fragment: fragment1), FragmentSpread(fragment: fragment2)])
         XCTAssertEqual(try! self.subject.graphQLString(), "fragment frag on CoolType {\n...frag1\n...frag2\n}")
+    }
+    
+    func testGraphQLStringWithDirectives() {
+        let scalar1 = Scalar(name: "scalar1", alias: "cool_scalar")
+        let scalar2 = Scalar(name: "scalar2", alias: nil)
+        let directive = Directive(name: "cool", arguments: ["best" : "directive"])
+        
+        self.subject = FragmentDefinition(name: "frag", type: "CoolType", fields: [scalar1, scalar2], fragments: nil, directives: [directive])
+        XCTAssertEqual(try! self.subject.graphQLString(), "fragment frag on CoolType @cool(best: \"directive\") {\ncool_scalar: scalar1\nscalar2\n}")
     }
 }
 
@@ -151,17 +181,22 @@ class OperationTests: XCTestCase {
     var subject: QueryBuilder.Operation!
     
     func testQueryForms() {
-        
         let scalar = Scalar(name: "name", alias: nil)
-        self.subject = QueryBuilder.Operation(type: .query, name: "Bullshit", fields: [scalar], fragments: nil, arguments: nil)
-        XCTAssertEqual(try! self.subject.graphQLString(), "query Bullshit {\nname\n}")
+        self.subject = QueryBuilder.Operation(type: .query, name: "Query", fields: [scalar], fragments: nil, arguments: nil)
+        XCTAssertEqual(try! self.subject.graphQLString(), "query Query {\nname\n}")
     }
     
     func testMutationForms() {
-        
         let scalar = Scalar(name: "name", alias: nil)
-        self.subject = QueryBuilder.Operation(type: .mutation, name: "Bullshit", fields: [scalar], fragments: nil, arguments: ["name" : "olga"])
-        XCTAssertEqual(try! self.subject.graphQLString(), "mutation Bullshit(name: \"olga\") {\nname\n}")
+        self.subject = QueryBuilder.Operation(type: .mutation, name: "Mutation", fields: [scalar], fragments: nil, arguments: ["name" : "olga"])
+        XCTAssertEqual(try! self.subject.graphQLString(), "mutation Mutation(name: \"olga\") {\nname\n}")
+    }
+    
+    func testDirectives() {
+        let scalar = Scalar(name: "name", alias: nil)
+        let directive = Directive(name: "cool", arguments: ["best" : "directive"])
+        self.subject = QueryBuilder.Operation(type: .mutation, name: "Mutation", fields: [scalar], fragments: nil, arguments: ["name" : "olga"], directives: [directive])
+        XCTAssertEqual(try! self.subject.graphQLString(), "mutation Mutation(name: \"olga\") @cool(best: \"directive\") {\nname\n}")
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ AutoGraphQL.Operation(type: .mutation, name: "MyCoolMutation", fields: [
 - [x] [Input Values](https://facebook.github.io/graphql/#sec-Input-Values)
     - [x] [List Values](https://facebook.github.io/graphql/#sec-List-Value)
     - [x] [Input Object Values](https://facebook.github.io/graphql/#sec-Input-Object-Values)
-- [ ] [Fragments](https://facebook.github.io/graphql/#sec-Language.Fragments)
-    - [ ] [Inline Fragments](https://facebook.github.io/graphql/#sec-Inline-Fragments)
-- [ ] [Directives](https://facebook.github.io/graphql/#sec-Language.Directives)
+- [x] [Fragments](https://facebook.github.io/graphql/#sec-Language.Fragments)
+    - [x] Fragment Spread
+    - [x] Fragment Definition
+- [ ] [Inline Fragments](https://facebook.github.io/graphql/#sec-Inline-Fragments)
+- [x] [Directives](https://facebook.github.io/graphql/#sec-Language.Directives)
 
 ## Crust for type safe Mapping
 AutoGraph relies entirely on [Crust](https://github.com/rexmas/Crust) for mapping JSON responses to models. Crust is a flexible framework that allows for the construction of multiple [Mappings](https://github.com/rexmas/Crust#how-to-map) to a single model and can simultaneously write to a corresponding database during mapping. Additionally, models can be represented by classes or structs.


### PR DESCRIPTION
* Cleaned up some error handling.
* Cleaned up usage of Fragments, FragmentSpread and FragmentDefinition are now separate such as in the language doc https://facebook.github.io/graphql/#sec-Language.Fragments .
* Added some documentation, this automatically gets added to our cocoadocs that are generated from cocoapods http://cocoadocs.org/docsets/AutoGraph/0.1.13/