### PR TITLE
Fix auth error handling

### DIFF
--- a/AutoGraph.xcodeproj/project.pbxproj
+++ b/AutoGraph.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CD3BFF3D1E22D270008CE41A /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3BFF391E22D270008CE41A /* RLMSupport.swift */; };
 		CD3BFF3F1E22D3E5008CE41A /* AlamofireClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3BFF3E1E22D3E5008CE41A /* AlamofireClient.swift */; };
 		CD5244531E70EC6B0040771D /* ErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5244521E70EC6B0040771D /* ErrorTests.swift */; };
+		CD79ABF81ED7918500A10629 /* Film401.json in Resources */ = {isa = PBXBuildFile; fileRef = CD79ABF71ED7918500A10629 /* Film401.json */; };
 		CDA62C031DB16999004BA66D /* AutoGraphQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDA62BF91DB16998004BA66D /* AutoGraphQL.framework */; };
 		CDA62C081DB16999004BA66D /* AutoGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA62C071DB16999004BA66D /* AutoGraphTests.swift */; };
 		CDA62C0A1DB16999004BA66D /* AutoGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA62BFC1DB16998004BA66D /* AutoGraph.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -98,6 +99,7 @@
 		CD3BFF391E22D270008CE41A /* RLMSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RLMSupport.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		CD3BFF3E1E22D3E5008CE41A /* AlamofireClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlamofireClient.swift; sourceTree = "<group>"; };
 		CD5244521E70EC6B0040771D /* ErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTests.swift; sourceTree = "<group>"; };
+		CD79ABF71ED7918500A10629 /* Film401.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Film401.json; sourceTree = "<group>"; };
 		CDA62BF91DB16998004BA66D /* AutoGraphQL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AutoGraphQL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDA62BFC1DB16998004BA66D /* AutoGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoGraph.h; sourceTree = "<group>"; };
 		CDA62BFD1DB16998004BA66D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				CDE3C7221E00C4A700AB4EB1 /* Stub.swift */,
 				CDE3C7241E00D23400AB4EB1 /* AllFilms.json */,
 				CD2014251E308CB600D16F14 /* Film.json */,
+				CD79ABF71ED7918500A10629 /* Film401.json */,
 				CDFC20431EB2CADD005D09DD /* VariableFilm.json */,
 				CDA62C091DB16999004BA66D /* Info.plist */,
 				CDE3C71E1E00C3BB00AB4EB1 /* AutoGraphTests-Bridging-Header.h */,
@@ -483,6 +486,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDE3C7251E00D23400AB4EB1 /* AllFilms.json in Resources */,
+				CD79ABF81ED7918500A10629 /* Film401.json in Resources */,
 				CDFC20441EB2CADD005D09DD /* VariableFilm.json in Resources */,
 				CD2014261E308CB600D16F14 /* Film.json in Resources */,
 			);

--- a/AutoGraph/AuthHandler.swift
+++ b/AutoGraph/AuthHandler.swift
@@ -12,6 +12,8 @@ public protocol ReauthenticationDelegate: class {
     func autoGraphRequiresReauthentication(accessToken: String?, refreshToken: String?, completion: RefreshCompletion)
 }
 
+public let Unauthorized401StatusCode = 401
+
 // NOTE: Currently too coupled to Alamofire, will need to write an adapter and
 // move some of this into AlamofireClient eventually.
 
@@ -73,7 +75,7 @@ extension AuthHandler: RequestRetrier {
             return
         }
         
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == Unauthorized401StatusCode else {
             completion(false, 0.0)
             return
         }

--- a/AutoGraph/AutoGraph.swift
+++ b/AutoGraph/AutoGraph.swift
@@ -13,7 +13,7 @@ public protocol Client: RequestSender, Cancellable {
     var sessionConfiguration: URLSessionConfiguration { get }
 }
 
-public typealias RequestCompletion<R> = (_ result: Result<R>) -> ()
+public typealias RequestCompletion<SerializedObject> = (_ result: Result<SerializedObject>) -> ()
 
 open class GlobalLifeCycle {
     open func willSend<R: Request>(request: R) throws { }
@@ -30,6 +30,15 @@ open class AutoGraph {
     public var authHandler: AuthHandler {
         get {
             return self.client.authHandler
+        }
+    }
+    
+    public var networkErrorParser: NetworkErrorParser? {
+        get {
+            return self.dispatcher.responseHandler.networkErrorParser
+        }
+        set {
+            self.dispatcher.responseHandler.networkErrorParser = newValue
         }
     }
     

--- a/AutoGraph/Errors.swift
+++ b/AutoGraph/Errors.swift
@@ -99,9 +99,9 @@ public indirect enum AutoGraphError: LocalizedError {
     }
 }
 
-public struct GraphQLError: LocalizedError {
+public struct GraphQLError: LocalizedError, Equatable {
     
-    public struct Location: CustomStringConvertible {
+    public struct Location: CustomStringConvertible, Equatable {
         public let line: Int
         public let column: Int
         
@@ -120,6 +120,10 @@ public struct GraphQLError: LocalizedError {
             
             self.line = Int(line)
             self.column = Int(column)
+        }
+        
+        public static func ==(lhs: Location, rhs: Location) -> Bool {
+            return lhs.line == rhs.line && lhs.column == rhs.column
         }
     }
     
@@ -146,5 +150,9 @@ public struct GraphQLError: LocalizedError {
             }
             return locations.flatMap { Location(json: $0) }
         }()
+    }
+    
+    public static func ==(lhs: GraphQLError, rhs: GraphQLError) -> Bool {
+        return lhs.message == rhs.message && lhs.locations == rhs.locations
     }
 }

--- a/AutoGraph/Request.swift
+++ b/AutoGraph/Request.swift
@@ -111,7 +111,7 @@ extension Request
 }
 
 extension Request where SerializedObject == Mapping.MappedObject {
-    func generateBinding(completion: @escaping RequestCompletion<Mapping.MappedObject>) -> ObjectBinding<Mapping, VoidMapping, Array<Int>, ThreadAdapterType> {
+    func generateBinding(completion: @escaping RequestCompletion<SerializedObject>) -> ObjectBinding<Mapping, VoidMapping, Array<Int>, ThreadAdapterType> {
         return ObjectBinding<Mapping, VoidMapping, Array<Int>, ThreadAdapterType>.object(mappingBinding: { self.mapping }, threadAdapter: threadAdapter, completion: completion)
     }
 }

--- a/AutoGraph/ResponseHandler.swift
+++ b/AutoGraph/ResponseHandler.swift
@@ -7,6 +7,7 @@ public class ResponseHandler {
     
     private let queue: OperationQueue
     private let callbackQueue: OperationQueue
+    public var networkErrorParser: NetworkErrorParser?
     
     init(queue: OperationQueue = OperationQueue(),
          callbackQueue: OperationQueue = OperationQueue.main) {
@@ -21,12 +22,7 @@ public class ResponseHandler {
         preMappingHook: (HTTPURLResponse?, JSONValue) throws -> ()) {
             
             do {
-                let value = try response.extractValue()
-                let json = try JSONValue(object: value)
-                
-                if let queryError = AutoGraphError(graphQLResponseJSON: json) {
-                    throw queryError
-                }
+                let json = try response.extractJSON(networkErrorParser: self.networkErrorParser ?? { _ in return nil })
                 
                 try preMappingHook(response.response, json)
                 

--- a/AutoGraph/Utilities.swift
+++ b/AutoGraph/Utilities.swift
@@ -44,10 +44,21 @@ extension DataResponse {
                         return nil
                 }
                 
-                return AutoGraphError(graphQLResponseJSON: json)
+                return AutoGraphError(graphQLResponseJSON: json, networkErrorParser: nil)
             }()
             
-            throw AutoGraphError.network(error: e, response: self.response, underlying: gqlError)
+            throw AutoGraphError.network(error: e, statusCode: self.response?.statusCode ?? -1, response: self.response, underlying: gqlError)
         }
+    }
+    
+    func extractJSON(networkErrorParser: @escaping NetworkErrorParser) throws -> JSONValue {
+        let value = try self.extractValue()
+        let json = try JSONValue(object: value)
+        
+        if let queryError = AutoGraphError(graphQLResponseJSON: json, networkErrorParser: networkErrorParser) {
+            throw queryError
+        }
+        
+        return json
     }
 }

--- a/AutoGraphTests/DispatcherTests.swift
+++ b/AutoGraphTests/DispatcherTests.swift
@@ -40,7 +40,7 @@ class DispatcherTests: XCTestCase {
     
     func testForwardsRequestToSender() {
         let request = AllFilmsRequest()
-        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBindingPromise: { _ in request.generateBinding(completion: { _ in }) }, globalWillSend: { _ in })
         
         self.mockRequestSender.testSendRequest = { url, params, completion in
             return (url == "localhost") && (params as! [String : String] == ["query" : try! request.query.graphQLString()])
@@ -53,7 +53,7 @@ class DispatcherTests: XCTestCase {
     
     func testHoldsRequestsWhenPaused() {
         let request = AllFilmsRequest()
-        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBindingPromise: { _ in request.generateBinding(completion: { _ in }) }, globalWillSend: { _ in })
         
         XCTAssertEqual(self.subject.pendingRequests.count, 0)
         self.subject.paused = true
@@ -63,7 +63,7 @@ class DispatcherTests: XCTestCase {
     
     func testClearsRequestsOnCancel() {
         let request = AllFilmsRequest()
-        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBindingPromise: { _ in request.generateBinding(completion: { _ in }) }, globalWillSend: { _ in })
         
         self.subject.paused = true
         self.subject.send(sendable: sendable)
@@ -74,7 +74,7 @@ class DispatcherTests: XCTestCase {
     
     func testForwardsAndClearsPendingRequestsOnUnpause() {
         let request = AllFilmsRequest()
-        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBindingPromise: { _ in request.generateBinding(completion: { _ in }) }, globalWillSend: { _ in })
         
         self.mockRequestSender.testSendRequest = { url, params, completion in
             return (url == "localhost") && (params as! [String : String] == ["query" : try! request.query.graphQLString()])
@@ -120,7 +120,7 @@ class DispatcherTests: XCTestCase {
             called = true
         }
         
-        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: objectBinding, globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBindingPromise: { _ in objectBinding }, globalWillSend: { _ in })
         
         self.subject.send(sendable: sendable)
         XCTAssertTrue(called)

--- a/AutoGraphTests/DispatcherTests.swift
+++ b/AutoGraphTests/DispatcherTests.swift
@@ -40,30 +40,33 @@ class DispatcherTests: XCTestCase {
     
     func testForwardsRequestToSender() {
         let request = AllFilmsRequest()
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
         
         self.mockRequestSender.testSendRequest = { url, params, completion in
             return (url == "localhost") && (params as! [String : String] == ["query" : try! request.query.graphQLString()])
         }
         
         XCTAssertFalse(self.mockRequestSender.expectation)
-        self.subject.send(request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        self.subject.send(sendable: sendable)
         XCTAssertTrue(self.mockRequestSender.expectation)
     }
     
     func testHoldsRequestsWhenPaused() {
         let request = AllFilmsRequest()
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
         
         XCTAssertEqual(self.subject.pendingRequests.count, 0)
         self.subject.paused = true
-        self.subject.send(request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        self.subject.send(sendable: sendable)
         XCTAssertEqual(self.subject.pendingRequests.count, 1)
     }
     
     func testClearsRequestsOnCancel() {
         let request = AllFilmsRequest()
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
         
         self.subject.paused = true
-        self.subject.send(request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        self.subject.send(sendable: sendable)
         XCTAssertEqual(self.subject.pendingRequests.count, 1)
         self.subject.cancelAll()
         XCTAssertEqual(self.subject.pendingRequests.count, 0)
@@ -71,13 +74,14 @@ class DispatcherTests: XCTestCase {
     
     func testForwardsAndClearsPendingRequestsOnUnpause() {
         let request = AllFilmsRequest()
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
         
         self.mockRequestSender.testSendRequest = { url, params, completion in
             return (url == "localhost") && (params as! [String : String] == ["query" : try! request.query.graphQLString()])
         }
         
         self.subject.paused = true
-        self.subject.send(request: request, objectBinding: request.generateBinding(completion: { _ in }), globalWillSend: { _ in })
+        self.subject.send(sendable: sendable)
         
         XCTAssertEqual(self.subject.pendingRequests.count, 1)
         XCTAssertFalse(self.mockRequestSender.expectation)
@@ -116,7 +120,9 @@ class DispatcherTests: XCTestCase {
             called = true
         }
         
-        self.subject.send(request: BadRequest(), objectBinding: objectBinding, globalWillSend: { _ in })
+        let sendable = Sendable(dispatcher: self.subject, request: request, objectBinding: objectBinding, globalWillSend: { _ in })
+        
+        self.subject.send(sendable: sendable)
         XCTAssertTrue(called)
     }
 }

--- a/AutoGraphTests/ErrorTests.swift
+++ b/AutoGraphTests/ErrorTests.swift
@@ -4,6 +4,11 @@ import Crust
 import JSONValueRX
 @testable import AutoGraphQL
 
+struct MockNetworkError: NetworkError {
+    let statusCode: Int
+    let underlyingError: GraphQLError
+}
+
 class ErrorTests: XCTestCase {
     func testGraphQLErrorUsesMessageForLocalizedDescription() {
         let message = "Cannot query field \"d\" on type \"Planet\"."
@@ -40,11 +45,6 @@ class ErrorTests: XCTestCase {
                 ]
             ]
         ]
-        
-        struct MockNetworkError: NetworkError {
-            let statusCode: Int
-            let underlyingError: GraphQLError
-        }
         
         let json = try! JSONValue(object: jsonObj)
         let error = AutoGraphError(graphQLResponseJSON: json) { gqlError -> NetworkError? in

--- a/AutoGraphTests/Film401.json
+++ b/AutoGraphTests/Film401.json
@@ -1,0 +1,26 @@
+{
+    "data": {
+        "film": null
+    },
+    "errors": [
+               {
+               "__restql_adapter__": {
+               "service_response": {
+               "error": "Unauthenticated",
+               "error_code": "unauthenticated"
+               },
+               "service_status": 401
+               },
+               "locations": [
+                             {
+                             "column": 1,
+                             "line": 3
+                             }
+                             ],
+               "message": "401 - {\"error\":\"Unauthenticated\",\"error_code\":\"unauthenticated\"}",
+               "path": [
+                        "film"
+                        ]
+               }
+               ]
+}


### PR DESCRIPTION
This allows the user to set a `NetworkErrorParser` on `AutoGraph` that can parse any `GraphQLError` in the `errors` payload of the json as check to see if it can be converted to a `NetworkError`. `NetworkError` has a `statusCode`, if this code is `401` then we pause the system for re-authentication which calls out to the application layer through an already existing delegate. 

Previously, we were only checking for 401s in the `HTTPUrlResponse` payload, but GraphQL attempts to return all network errors in the errors payload since different parts of the request may be resolved by different services. In other words, a network error will usually return a 200 at the http response level, but have the network error embedded into the `errors` payload of the response.