### PR TITLE
[fix-invalid-response-crash] 

### DIFF
--- a/AutoGraph/Errors.swift
+++ b/AutoGraph/Errors.swift
@@ -94,7 +94,7 @@ public indirect enum AutoGraphError: LocalizedError {
             return "Type \(from) cannot be cast to type \(to)"
             
         case .invalidResponse:
-            return self.localizedDescription
+            return "Invalid Response"
         }
     }
 }

--- a/AutoGraphTests/ErrorTests.swift
+++ b/AutoGraphTests/ErrorTests.swift
@@ -10,6 +10,11 @@ struct MockNetworkError: NetworkError {
 }
 
 class ErrorTests: XCTestCase {
+    func testInvalidResponseLocalizedErrorDoesntCrash() {
+        let description = AutoGraphError.invalidResponse.localizedDescription
+        XCTAssertGreaterThan(description.characters.count, 0)
+    }
+    
     func testGraphQLErrorUsesMessageForLocalizedDescription() {
         let message = "Cannot query field \"d\" on type \"Planet\"."
         let line = 18


### PR DESCRIPTION
calling localizedDescription on self was giving an EXC_BAD_ACCESS