### PR TITLE
Result.success(value:, json:)

### DIFF
--- a/AutoGraph/AutoGraph.swift
+++ b/AutoGraph/AutoGraph.swift
@@ -14,7 +14,7 @@ public protocol Client: RequestSender, Cancellable {
     var sessionConfiguration: URLSessionConfiguration { get }
 }
 
-public typealias RequestCompletion<SerializedObject> = (_ result: Result<(SerializedObject, JSONValue)>) -> ()
+public typealias RequestCompletion<SerializedObject> = (_ result: Result<SerializedObject>) -> ()
 
 open class GlobalLifeCycle {
     open func willSend<R: Request>(request: R) throws { }
@@ -98,7 +98,7 @@ open class AutoGraph {
         self.dispatcher.send(sendable: sendable)
     }
     
-    private func complete<SerializedObject>(result: Result<(SerializedObject, JSONValue)>, sendable: Sendable, requestDidFinish: (Result<(SerializedObject, JSONValue)>) throws -> (), completion: @escaping RequestCompletion<SerializedObject>) {
+    private func complete<SerializedObject>(result: Result<SerializedObject>, sendable: Sendable, requestDidFinish: (Result<SerializedObject>) throws -> (), completion: @escaping RequestCompletion<SerializedObject>) {
         
         do {
             try self.raiseAuthenticationError(from: result)

--- a/AutoGraph/Request.swift
+++ b/AutoGraph/Request.swift
@@ -57,7 +57,7 @@ public protocol Request {
     func didFinishRequest(response: HTTPURLResponse?, json: JSONValue) throws
     
     /// Called right before calling the completion handler for the sent request, i.e. at the end of the lifecycle.
-    func didFinish(result: AutoGraphQL.Result<(SerializedObject, JSONValue)>) throws
+    func didFinish(result: AutoGraphQL.Result<SerializedObject>) throws
 }
 
 /// A `Request` where the result objects can safely be transmitted across threads without special handling.

--- a/AutoGraph/ResponseHandler.swift
+++ b/AutoGraph/ResponseHandler.swift
@@ -50,7 +50,7 @@ open class ResponseHandler {
                     }
                     else {
                         self.callbackQueue.addOperation {
-                            completion(.success((result, json)))
+                            completion(.success(value: result, json: json))
                         }
                     }
                     
@@ -63,7 +63,7 @@ open class ResponseHandler {
                     }
                     else {
                         self.callbackQueue.addOperation {
-                            completion(.success((result, json)))
+                            completion(.success(value: result, json: json))
                         }
                     }
                 }
@@ -107,7 +107,7 @@ open class ResponseHandler {
                     
                     do {
                         let objects = try threadAdapter.retrieveObjects(for: representation)
-                        completion(.success((try strongSelf.coerceToType(objects.first), json)))
+                        completion(.success(value: try strongSelf.coerceToType(objects.first), json: json))
                     }
                     catch let e {
                         strongSelf.fail(error: AutoGraphError.refetching(error: e), completion: completion)
@@ -136,7 +136,7 @@ open class ResponseHandler {
                     
                     do {
                         let objects = try threadAdapter.retrieveObjects(for: representation)
-                        completion(.success((try strongSelf.coerceToType(objects), json)))
+                        completion(.success(value: try strongSelf.coerceToType(objects), json: json))
                     }
                     catch let e {
                         strongSelf.fail(error: AutoGraphError.refetching(error: e), completion: completion)

--- a/AutoGraph/Utilities.swift
+++ b/AutoGraph/Utilities.swift
@@ -4,26 +4,8 @@ import Foundation
 import JSONValueRX
 
 public enum Result<Value> {
-    case success(Value)
+    case success(value: Value, json: JSONValue)
     case failure(Error)
-    
-    public func map<U>(_ transform: (Value) -> U) -> Result<U> {
-        switch self {
-        case .success(let val):
-            return .success(transform(val))
-        case .failure(let e):
-            return .failure(e)
-        }
-    }
-    
-    public func flatMap<U>(_ transform: (Value) -> Result<U>) -> Result<U> {
-        switch self {
-        case .success(let val):
-            return transform(val)
-        case .failure(let e):
-            return .failure(e)
-        }
-    }
 }
 
 extension DataResponse {

--- a/AutoGraphRealmTests/AllFilmsRequest.swift
+++ b/AutoGraphRealmTests/AllFilmsRequest.swift
@@ -51,7 +51,7 @@ class AllFilmsRequest: Request {
     
     public func willSend() throws { }
     public func didFinishRequest(response: HTTPURLResponse?, json: JSONValue) throws { }
-    public func didFinish(result: Result<([Film], JSONValue)>) throws { }
+    public func didFinish(result: Result<[Film]>) throws { }
 }
 
 class AllFilmsStub: Stub {

--- a/AutoGraphRealmTests/AutoGraphRealmTests.swift
+++ b/AutoGraphRealmTests/AutoGraphRealmTests.swift
@@ -58,9 +58,6 @@ class AutoGraphTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let config = RLMRealmConfiguration()
-        config.inMemoryIdentifier = self.name
-        RLMRealmConfiguration.setDefault(config)
         _ = RLMRealm.default()
         self.subject = AutoGraph()
     }

--- a/AutoGraphRealmTests/AutoGraphRealmTests.swift
+++ b/AutoGraphRealmTests/AutoGraphRealmTests.swift
@@ -23,7 +23,7 @@ class FilmRequestWithLifeCycle: FilmRequest {
     }
     
     var didFinishCalled = false
-    override func didFinish(result: AutoGraphQL.Result<(FilmRequest.SerializedObject, JSONValue)>) throws {
+    override func didFinish(result: AutoGraphQL.Result<FilmRequest.SerializedObject>) throws {
         didFinishCalled = true
     }
 }
@@ -58,6 +58,9 @@ class AutoGraphTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
+        let config = RLMRealmConfiguration()
+        config.inMemoryIdentifier = self.name
+        RLMRealmConfiguration.setDefault(config)
         _ = RLMRealm.default()
         self.subject = AutoGraph()
     }
@@ -244,10 +247,10 @@ class AutoGraphTests: XCTestCase {
             
             var didFinishCalled = false
             override func didFinish<SerializedObject>(result: AutoGraphQL.Result<SerializedObject>) throws {
-                guard case .success(let value) = result else {
+                guard case .success(let value, _) = result else {
                     return
                 }
-                didFinishCalled = value is (Film, JSONValue)
+                didFinishCalled = value is Film
             }
         }
         

--- a/AutoGraphRealmTests/DispatcherRealmTests.swift
+++ b/AutoGraphRealmTests/DispatcherRealmTests.swift
@@ -94,7 +94,7 @@ class DispatcherTests: XCTestCase {
     }
     
     class BadRequest: AutoGraphQL.Request {
-        func didFinish(result: AutoGraphQL.Result<(Film, JSONValue)>) throws {
+        func didFinish(result: AutoGraphQL.Result<Film>) throws {
         }
         
         struct BadQuery: GraphQLDocument {

--- a/AutoGraphRealmTests/FilmRequest.swift
+++ b/AutoGraphRealmTests/FilmRequest.swift
@@ -5,9 +5,6 @@ import JSONValueRX
 import Realm
 
 class FilmRequest: Request {
-    func didFinish(result: Result<(Film, JSONValue)>) throws {
-    }
-    
     /*
      query film {
         film(id: "ZmlsbXM6MQ==") {
@@ -106,7 +103,7 @@ class FilmStub: Stub {
 }
 
 class FilmThreadUnconfinedRequest: ThreadUnconfinedRequest {
-    func didFinish(result: Result<(FilmThreadUnconfined, JSONValue)>) throws {
+    func didFinish(result: Result<FilmThreadUnconfined>) throws {
     }
     
     /*

--- a/AutoGraphRealmTests/VariableFilmRequest.swift
+++ b/AutoGraphRealmTests/VariableFilmRequest.swift
@@ -29,7 +29,7 @@ struct VariableFilm: AnyMappable, ThreadAdaptable {
 }
 
 class VariableFilmRequest: Request {
-    func didFinish(result: Result<(VariableFilm, JSONValue)>) throws {
+    func didFinish(result: Result<VariableFilm>) throws {
     }
     
     typealias SerializedObject = VariableFilm

--- a/AutoGraphTests/AutoGraphTests.swift
+++ b/AutoGraphTests/AutoGraphTests.swift
@@ -17,7 +17,7 @@ class FilmRequestWithLifeCycle: FilmRequest {
     }
     
     var didFinishCalled = false
-    override func didFinish(result: AutoGraphQL.Result<(FilmRequest.SerializedObject, JSONValue)>) throws {
+    override func didFinish(result: AutoGraphQL.Result<FilmRequest.SerializedObject>) throws {
         didFinishCalled = true
     }
 }
@@ -204,10 +204,10 @@ class AutoGraphTests: XCTestCase {
             
             var didFinishCalled = false
             override func didFinish<SerializedObject>(result: AutoGraphQL.Result<SerializedObject>) throws {
-                guard case .success(let value) = result else {
+                guard case .success(let value, _) = result else {
                     return
                 }
-                didFinishCalled = value is (Film, JSONValue)
+                didFinishCalled = value is Film
             }
         }
         

--- a/AutoGraphTests/DispatcherTests.swift
+++ b/AutoGraphTests/DispatcherTests.swift
@@ -94,7 +94,7 @@ class DispatcherTests: XCTestCase {
     }
     
     class BadRequest: AutoGraphQL.ThreadUnconfinedRequest {
-        func didFinish(result: AutoGraphQL.Result<(Film, JSONValue)>) throws {
+        func didFinish(result: AutoGraphQL.Result<Film>) throws {
         }
         
         struct BadQuery: GraphQLDocument {

--- a/AutoGraphTests/Requests/AllFilmsRequest.swift
+++ b/AutoGraphTests/Requests/AllFilmsRequest.swift
@@ -47,7 +47,7 @@ class AllFilmsRequest: ThreadUnconfinedRequest {
     
     public func willSend() throws { }
     public func didFinishRequest(response: HTTPURLResponse?, json: JSONValue) throws { }
-    public func didFinish(result: Result<([Film], JSONValue)>) throws { }
+    public func didFinish(result: Result<[Film]>) throws { }
 }
 
 class AllFilmsStub: Stub {

--- a/AutoGraphTests/Requests/FilmRequest.swift
+++ b/AutoGraphTests/Requests/FilmRequest.swift
@@ -40,7 +40,7 @@ class FilmRequest: ThreadUnconfinedRequest {
     
     public func willSend() throws { }
     public func didFinishRequest(response: HTTPURLResponse?, json: JSONValue) throws { }
-    public func didFinish(result: Result<(Film, JSONValue)>) throws { }
+    public func didFinish(result: Result<Film>) throws { }
 }
 
 class FilmStub: Stub {


### PR DESCRIPTION
As soon as I started using the previous json code (#85) I realized it'd be a lot better if they were named properties of the Result.success enum case.