### PR TITLE
[open-send] 

### DIFF
--- a/AutoGraph/AutoGraph.swift
+++ b/AutoGraph/AutoGraph.swift
@@ -62,7 +62,7 @@ open class AutoGraph {
         self.client.authHandler.delegate = self
     }
     
-    public func send<R: Request>(_ request: R, completion: @escaping RequestCompletion<R.SerializedObject>)
+    open func send<R: Request>(_ request: R, completion: @escaping RequestCompletion<R.SerializedObject>)
     where R.SerializedObject == R.Mapping.MappedObject {
         
         let objectBindingPromise = { sendable in


### PR DESCRIPTION
mark send as open so you can use it for mocking