### PR TITLE
[query-builder-cleanup] pt1

### DIFF
--- a/QueryBuilder/FoundationExtensions.swift
+++ b/QueryBuilder/FoundationExtensions.swift
@@ -19,7 +19,7 @@ enum QueryBuilderError: LocalizedError {
         case .missingFields(selectionSetName: let selectionSetName):
             return "Selection Set on \(selectionSetName) must have either `fields` or `fragments` or both"
         case .selectionMergeFailure(selection1: let selection1, selection2: let selection2):
-            return "Cannot merge selection \(selection1.key) of kind \(selection1.kind) with selection \(selection2.key) of kind \(selection2.kind)"
+            return "Cannot merge selection \(selection1.selectionSetDebugName) of kind \(selection1.kind) with selection \(selection2.selectionSetDebugName) of kind \(selection2.kind)"
         }
     }
 }
@@ -120,6 +120,10 @@ extension String: ScalarField, InputValue, GraphQLDocument {
     }
 
     public var alias: String? {
+        return nil
+    }
+    
+    public var arguments: [String : InputValue]? {
         return nil
     }
     

--- a/QueryBuilderTests/FoundationExtensionsTests.swift
+++ b/QueryBuilderTests/FoundationExtensionsTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import AutoGraphQL
 
 class FoundationExtensionsTests: XCTestCase {
-    
     func testArgumentStringJsonEncodes() {
         XCTAssertEqual(try! "arg arg".graphQLInputValue(), "\"arg arg\"")
     }


### PR DESCRIPTION
* Cleaned up a lot of naming and semantics
* Gave Scalars the ability to have arguments and directives, like they should
* Made merging selection sets properly respect those arguments and directives

Now that the only difference between Objects and Scalars is a Selection set, will attempt to just merge to two together into a concrete Field type in the next PR for simplicity.