### PR TITLE
Cleaner json api

### DIFF
--- a/AutoGraph/AutoGraph.swift
+++ b/AutoGraph/AutoGraph.swift
@@ -77,6 +77,11 @@ open class AutoGraph {
         self.dispatcher.send(sendable: sendable)
     }
     
+    open func send<R: Request>(includingJSONResponse request: R, completion: @escaping (_ result: ResultIncludingJSON<R.SerializedObject>) -> ()) {
+        let requestIncludingJSON = RequestIncludingJSON(request: request)
+        self.send(requestIncludingJSON, completion: completion)
+    }
+    
     private func complete<SerializedObject>(result: AutoGraphResult<SerializedObject>, sendable: Sendable, requestDidFinish: (AutoGraphResult<SerializedObject>) throws -> (), completion: @escaping RequestCompletion<SerializedObject>) {
         
         do {

--- a/AutoGraph/Request.swift
+++ b/AutoGraph/Request.swift
@@ -30,11 +30,58 @@ public protocol Request {
 
 /// A weird enum that collects info for a request.
 public enum ObjectBinding<SerializedObject: Decodable> {
-    case object(keyPath: String, completion: RequestCompletion<SerializedObject>)
+    case object(keyPath: String, isRequestIncludingJSON: Bool, completion: RequestCompletion<SerializedObject>)
 }
 
 extension Request {
     func generateBinding(completion: @escaping RequestCompletion<SerializedObject>) -> ObjectBinding<SerializedObject> {
-        return ObjectBinding<SerializedObject>.object(keyPath: self.rootKeyPath, completion: completion)
+        return ObjectBinding<SerializedObject>.object(keyPath: self.rootKeyPath, isRequestIncludingJSON: self is IsRequestIncludingJSON, completion: completion)
+    }
+}
+
+private protocol IsRequestIncludingJSON {}
+extension RequestIncludingJSON: IsRequestIncludingJSON {}
+
+public struct DataIncludingJSON<T: Decodable>: Decodable {
+    public let value: T
+    public let json: JSONValue
+}
+
+public struct RequestIncludingJSON<R: Request>: Request {
+    public typealias SerializedObject = DataIncludingJSON<R.SerializedObject>
+    public typealias QueryDocument = R.QueryDocument
+    public typealias Variables = R.Variables
+    
+    public let request: R
+    
+    public var queryDocument: R.QueryDocument {
+        return request.queryDocument
+    }
+    
+    public var variables: R.Variables? {
+        return request.variables
+    }
+    
+    public var rootKeyPath: String {
+        return request.rootKeyPath
+    }
+    
+    public func willSend() throws {
+        try request.willSend()
+    }
+    
+    public func didFinishRequest(response: HTTPURLResponse?, json: JSONValue) throws {
+        try request.didFinishRequest(response: response, json: json)
+    }
+    
+    public func didFinish(result: Result<DataIncludingJSON<R.SerializedObject>, Error>) throws {
+        try request.didFinish(result: {
+            switch result {
+            case .success(let data):
+                return .success(data.value)
+            case .failure(let error):
+                return .failure(error)
+            }
+        }())
     }
 }

--- a/AutoGraph/Utilities.swift
+++ b/AutoGraph/Utilities.swift
@@ -2,7 +2,8 @@ import Alamofire
 import Foundation
 import JSONValueRX
 
-public typealias AutoGraphResult<Value> = Swift.Result<(Value, JSONValue), Error>
+public typealias AutoGraphResult<Value> = Swift.Result<Value, Error>
+public typealias ResultIncludingJSON<Value: Decodable> = AutoGraphResult<DataIncludingJSON<Value>>
 
 extension DataResponse {
     func extractValue() throws -> Any {

--- a/AutoGraphTests/AutoGraphTests.swift
+++ b/AutoGraphTests/AutoGraphTests.swift
@@ -239,7 +239,6 @@ class AutoGraphTests: XCTestCase {
         var called = false
         self.subject.send(includingJSONResponse: request) { result in
             called = true
-            print(result)
             guard case .success(let data) = result else {
                 XCTFail()
                 return

--- a/AutoGraphTests/AutoGraphTests.swift
+++ b/AutoGraphTests/AutoGraphTests.swift
@@ -180,15 +180,15 @@ class AutoGraphTests: XCTestCase {
         class GlobalLifeCycleMock: GlobalLifeCycle {
             var willSendCalled = false
             override func willSend<R : AutoGraphQL.Request>(request: R) throws {
-                willSendCalled = request is FilmRequest
+                self.willSendCalled = request is FilmRequest
             }
             
             var didFinishCalled = false
             override func didFinish<SerializedObject>(result: AutoGraphResult<SerializedObject>) throws {
-                guard case .success(let value, _) = result else {
+                guard case .success(let value) = result else {
                     return
                 }
-                didFinishCalled = value is Film
+                self.didFinishCalled = value is Film
             }
         }
         
@@ -211,10 +211,10 @@ class AutoGraphTests: XCTestCase {
         class GlobalLifeCycleMock: GlobalLifeCycle {
             var gotArray = false
             override func didFinish<SerializedObject>(result: AutoGraphResult<SerializedObject>) throws {
-                guard case .success(let value, _) = result else {
+                guard case .success(let value) = result else {
                     return
                 }
-                gotArray = value is [Film]
+                self.gotArray = value is [Film]
             }
         }
         
@@ -229,6 +229,29 @@ class AutoGraphTests: XCTestCase {
         
         waitFor(delay: kDelay)
         XCTAssertTrue(lifeCycle.gotArray)
+    }
+    
+    func testRequestIncludingJSON() {
+        let stub = AllFilmsStub()
+        stub.registerStub()
+        let request = AllFilmsRequest()
+        
+        var called = false
+        self.subject.send(includingJSONResponse: request) { result in
+            called = true
+            print(result)
+            guard case .success(let data) = result else {
+                XCTFail()
+                return
+            }
+            
+            let json = try! JSONValue(object: stub.json)
+            XCTAssertEqual(data.json, json[request.rootKeyPath])
+            XCTAssertEqual(data.value, [Film(remoteId: "ZmlsbXM6MQ==", title: "A New Hope", episode: 4, openingCrawl: "It is a period of civil war.\r\nRebel spaceships, striking\r\nfrom a hidden base, have won\r\ntheir first victory against\r\nthe evil Galactic Empire.\r\n\r\nDuring the battle, Rebel\r\nspies managed to steal secret\r\nplans to the Empire\'s\r\nultimate weapon, the DEATH\r\nSTAR, an armored space\r\nstation with enough power\r\nto destroy an entire planet.\r\n\r\nPursued by the Empire\'s\r\nsinister agents, Princess\r\nLeia races home aboard her\r\nstarship, custodian of the\r\nstolen plans that can save her\r\npeople and restore\r\nfreedom to the galaxy....", director: "George Lucas"), Film(remoteId: "ZmlsbXM6Mg==", title: "The Empire Strikes Back", episode: 5, openingCrawl: "It is a dark time for the\r\nRebellion. Although the Death\r\nStar has been destroyed,\r\nImperial troops have driven the\r\nRebel forces from their hidden\r\nbase and pursued them across\r\nthe galaxy.\r\n\r\nEvading the dreaded Imperial\r\nStarfleet, a group of freedom\r\nfighters led by Luke Skywalker\r\nhas established a new secret\r\nbase on the remote ice world\r\nof Hoth.\r\n\r\nThe evil lord Darth Vader,\r\nobsessed with finding young\r\nSkywalker, has dispatched\r\nthousands of remote probes into\r\nthe far reaches of space....", director: "Irvin Kershner"), Film(remoteId: "ZmlsbXM6Mw==", title: "Return of the Jedi", episode: 6, openingCrawl: "Luke Skywalker has returned to\r\nhis home planet of Tatooine in\r\nan attempt to rescue his\r\nfriend Han Solo from the\r\nclutches of the vile gangster\r\nJabba the Hutt.\r\n\r\nLittle does Luke know that the\r\nGALACTIC EMPIRE has secretly\r\nbegun construction on a new\r\narmored space station even\r\nmore powerful than the first\r\ndreaded Death Star.\r\n\r\nWhen completed, this ultimate\r\nweapon will spell certain doom\r\nfor the small band of rebels\r\nstruggling to restore freedom\r\nto the galaxy...", director: "Richard Marquand"), Film(remoteId: "ZmlsbXM6NA==", title: "The Phantom Menace", episode: 1, openingCrawl: "Turmoil has engulfed the\r\nGalactic Republic. The taxation\r\nof trade routes to outlying star\r\nsystems is in dispute.\r\n\r\nHoping to resolve the matter\r\nwith a blockade of deadly\r\nbattleships, the greedy Trade\r\nFederation has stopped all\r\nshipping to the small planet\r\nof Naboo.\r\n\r\nWhile the Congress of the\r\nRepublic endlessly debates\r\nthis alarming chain of events,\r\nthe Supreme Chancellor has\r\nsecretly dispatched two Jedi\r\nKnights, the guardians of\r\npeace and justice in the\r\ngalaxy, to settle the conflict....", director: "George Lucas"), Film(remoteId: "ZmlsbXM6NQ==", title: "Attack of the Clones", episode: 2, openingCrawl: "There is unrest in the Galactic\r\nSenate. Several thousand solar\r\nsystems have declared their\r\nintentions to leave the Republic.\r\n\r\nThis separatist movement,\r\nunder the leadership of the\r\nmysterious Count Dooku, has\r\nmade it difficult for the limited\r\nnumber of Jedi Knights to maintain \r\npeace and order in the galaxy.\r\n\r\nSenator Amidala, the former\r\nQueen of Naboo, is returning\r\nto the Galactic Senate to vote\r\non the critical issue of creating\r\nan ARMY OF THE REPUBLIC\r\nto assist the overwhelmed\r\nJedi....", director: "George Lucas"), Film(remoteId: "ZmlsbXM6Ng==", title: "Revenge of the Sith", episode: 3, openingCrawl: "War! The Republic is crumbling\r\nunder attacks by the ruthless\r\nSith Lord, Count Dooku.\r\nThere are heroes on both sides.\r\nEvil is everywhere.\r\n\r\nIn a stunning move, the\r\nfiendish droid leader, General\r\nGrievous, has swept into the\r\nRepublic capital and kidnapped\r\nChancellor Palpatine, leader of\r\nthe Galactic Senate.\r\n\r\nAs the Separatist Droid Army\r\nattempts to flee the besieged\r\ncapital with their valuable\r\nhostage, two Jedi Knights lead a\r\ndesperate mission to rescue the\r\ncaptive Chancellor....", director: "George Lucas")])
+        }
+        
+        waitFor(delay: kDelay)
+        XCTAssertTrue(called)
     }
     
     func testCancelAllCancelsDispatcherAndClient() {

--- a/AutoGraphTests/Data/Film.swift
+++ b/AutoGraphTests/Data/Film.swift
@@ -1,11 +1,13 @@
+import AutoGraphQL
 import Foundation
+import JSONValueRX
 
 struct Film: Decodable, Equatable {
-    var remoteId: String
-    var title: String
-    var episode: Int
-    var openingCrawl: String
-    var director: String
+    let remoteId: String
+    let title: String
+    let episode: Int
+    let openingCrawl: String
+    let director: String
     
     enum CodingKeys: String, CodingKey {
         case remoteId = "id"

--- a/AutoGraphTests/Stub.swift
+++ b/AutoGraphTests/Stub.swift
@@ -31,10 +31,11 @@ class Stub {
             #else
             let fileManager = FileManager.default
             let currentDirectoryPath = fileManager.currentDirectoryPath
-            return "\(currentDirectoryPath)/AutoGraphTests/Data/\(self.jsonFixtureFile).json"
+            return "\(currentDirectoryPath)/AutoGraphTests/Data/\(self.jsonFixtureFile!).json"
             
             #endif
         }()
+        print("loading stub at path: \(path)")
         return FileManager.default.contents(atPath: path)!
     }
     

--- a/AutoGraphTests/Stub.swift
+++ b/AutoGraphTests/Stub.swift
@@ -18,27 +18,24 @@ class Stub {
         AllStubs.removeAll()
     }
     
-    var json: Any? {
-        if let jsonFixtureFile = self.jsonFixtureFile {
-            let path: String = {
-                #if os(iOS)
-                return Bundle(for: type(of: self)).path(forResource: jsonFixtureFile, ofType: "json")!
-                
-                #else
-                let fileManager = FileManager.default
-                let currentDirectoryPath = fileManager.currentDirectoryPath
-                return "\(currentDirectoryPath)/AutoGraphTests/Data/\(jsonFixtureFile).json"
-                
-                #endif
-            }()
-            if let jsonData = NSData(contentsOfFile: path) {
-                if let jsonResult = try? JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions(rawValue: UInt(0))) {
-                    return jsonResult
-                }
-            }
-        }
-        
-        return nil
+    var json: Any {
+        return try! JSONSerialization.jsonObject(with: self.jsonData)
+    }
+    
+    var jsonData: Data {
+        precondition(self.jsonFixtureFile != nil, "Stub is missing jsonFixtureFile: \(self)")
+        let path: String = {
+            #if os(iOS)
+            return Bundle(for: type(of: self)).path(forResource: self.jsonFixtureFile, ofType: "json")!
+            
+            #else
+            let fileManager = FileManager.default
+            let currentDirectoryPath = fileManager.currentDirectoryPath
+            return "\(currentDirectoryPath)/AutoGraphTests/Data/\(self.jsonFixtureFile).json"
+            
+            #endif
+        }()
+        return FileManager.default.contents(atPath: path)!
     }
     
     var graphQLQuery: String = ""
@@ -52,7 +49,7 @@ class Stub {
     var jsonFixtureFile: String?
     
     var responseData: Data? {
-        let data = try! JSONSerialization.data(withJSONObject: self.json!, options: JSONSerialization.WritingOptions(rawValue: 0))
+        let data = try! JSONSerialization.data(withJSONObject: self.json, options: JSONSerialization.WritingOptions(rawValue: 0))
         return data
     }
     

--- a/AutoGraphTests/XCTestManifests.swift
+++ b/AutoGraphTests/XCTestManifests.swift
@@ -40,6 +40,7 @@ extension AutoGraphTests {
         ("testFunctionalGlobalLifeCycle", testFunctionalGlobalLifeCycle),
         ("testFunctionalLifeCycle", testFunctionalLifeCycle),
         ("testFunctionalSingleFilmRequest", testFunctionalSingleFilmRequest),
+        ("testRequestIncludingJSON", testRequestIncludingJSON),
         ("testTriggeringReauthenticationPausesSystem", testTriggeringReauthenticationPausesSystem),
     ]
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/rexmas/JSONValue.git",
         "state": {
           "branch": null,
-          "revision": "e7648a3aa5036f70376605419605263a48f15fdb",
-          "version": "5.0.0"
+          "revision": "358b41b51fd06e67fb4813dd11960986e11691ae",
+          "version": "5.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "4.8.2")),
-        .package(url: "https://github.com/rexmas/JSONValue.git", .upToNextMinor(from: "5.0.0"))
+        .package(url: "https://github.com/rexmas/JSONValue.git", .upToNextMinor(from: "5.1.0"))
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ inhibit_all_warnings!
 use_frameworks!
 
 def jsonvalue
-  pod 'JSONValueRX', '~> 5.0'
+  pod 'JSONValueRX', '~> 5.1'
 end
 
 target 'AutoGraphQL' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Alamofire (4.8.2)
-  - JSONValueRX (5.0.0)
+  - JSONValueRX (5.1.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.2)
-  - JSONValueRX (~> 5.0)
+  - JSONValueRX (~> 5.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -13,8 +13,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  JSONValueRX: 258132f6686c21585009c006b0451ba45b3bc693
+  JSONValueRX: e11fe4afb8ba1701f2eeefb9de707233ef498e4c
 
-PODFILE CHECKSUM: 6de0cab2d0052f4c15f150c873e48819ceca4163
+PODFILE CHECKSUM: 0d59adcae66a571e3921a1361f48d5bdd74f54d1
 
 COCOAPODS: 1.6.1

--- a/Pods/JSONValueRX/README.md
+++ b/Pods/JSONValueRX/README.md
@@ -78,14 +78,76 @@ let hashable2 = try! JSONValue(object: ["drive" : "warp"])
 print(hashable1.hashValue) // -7189088994080390660
 print(hashable2.hashValue) // -215843780535174243
 ```
-# Encoding/Decoding from String, Data
+
+# Codable
+
+#### Decode from JSON to JSONValue
+
+```swift
+let jsonString = """
+{
+    "_id": "5d140a3fb5bbd5eaa41b512e",
+    "guid": "9b0f3717-2f21-4a81-8902-92d2278a92f0",
+    "isActive": false,
+    "age": 30
+}
+"""
+let jsonValue = try! JSONDecoder().decode(JSONValue.self, from: jsonString.data(using: .utf8)!)
+```
+
+#### Encode JSONValue to JSON
+
+```swift
+let jsonValue = JSONValue.object(["_id" : .string("5d140a3fb5bbd5eaa41b512e")])
+let jsonData = try! JSONEncoder().encode(jsonValue)
+```
+
+#### Decode from JSONValue to a Struct
+
+```swift
+let jsonValue = JSONValue.array([
+    .object([
+        "_id": .string("5d140a3fb5bbd5eaa41b512e"),
+        "guid": .string("9b0f3717-2f21-4a81-8902-92d2278a92f0"),
+        "isActive": .bool(false),
+        "age": .number(30),
+        "name": .object([
+        "first": .string("Rosales"),
+        "last": .string("Mcintosh")
+        ]),
+        "company": JSONValue.null,
+        "latitude": .string("-58.182284"),
+        "longitude": .string("-159.420718"),
+        "tags": .array([
+        .string("aute"),
+        .string("aute")
+        ])
+    ])
+])
+
+struct Output: Decodable, Equatable {
+    let _id: String
+    let guid: String
+    let isActive: Bool
+    let age: Int
+    let name: [String: String]
+    let company: String?
+    let latitude: String
+    let longitude: String
+    let tags: [String]
+}
+
+let output: Array<Output> = try! jsonValue.decode()
+```
+
+# Encoding/Decoding from String, Data without Codable
 ```swift
 public func encode() throws -> Data
 public static func decode(_ data: Data) throws -> JSONValue
 public static func decode(_ string: String) throws -> JSONValue
 ```
 
-# Custom Encoding/Decoding
+# Custom Encoding/Decoding without Codable
 ```swift
 public protocol JSONDecodable {
     associatedtype ConversionType = Self

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,10 +1,10 @@
 PODS:
   - Alamofire (4.8.2)
-  - JSONValueRX (5.0.0)
+  - JSONValueRX (5.1.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.2)
-  - JSONValueRX (~> 5.0)
+  - JSONValueRX (~> 5.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -13,8 +13,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  JSONValueRX: 258132f6686c21585009c006b0451ba45b3bc693
+  JSONValueRX: e11fe4afb8ba1701f2eeefb9de707233ef498e4c
 
-PODFILE CHECKSUM: 6de0cab2d0052f4c15f150c873e48819ceca4163
+PODFILE CHECKSUM: 0d59adcae66a571e3921a1361f48d5bdd74f54d1
 
 COCOAPODS: 1.6.1

--- a/Pods/Target Support Files/JSONValueRX/JSONValueRX-Info.plist
+++ b/Pods/Target Support Files/JSONValueRX/JSONValueRX-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.0.0</string>
+  <string>5.1.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
Call `autograph.send(includingJSONResponse: request)` and it will return a result (data, error) where `data.value` is the serialized object value and `data.json` is the json value. This keeps the API cleaner. No additional tuples inside of the success result and user can choose to request the wrapped struct with json only if they actually want it.

We should probably change the name of `data.value` though, maybe `data.serializedObject`?