### PR TITLE
Connection type update

### DIFF
--- a/AutoGraph/AutoGraph.swift
+++ b/AutoGraph/AutoGraph.swift
@@ -101,7 +101,7 @@ open class AutoGraph {
     /// immediate failure, in which case, please check the error received in the completion block.
     ///
     /// It will form a websocket connection if one doesn't exist already.
-    open func subscribe<R: Request>(_ request: R, connectionState: @escaping SubscriptionResponseHandler.WebSocketConnectionBlock, completion: @escaping RequestCompletion<R.SerializedObject>) -> Subscriber? {
+    open func subscribe<R: Request>(_ request: R, completion: @escaping RequestCompletion<R.SerializedObject>) -> Subscriber? {
         guard let webSocketClient = self.webSocketClient else {
             completion(.failure(AutoGraphError.subscribeWithMissingWebSocketClient))
             return nil
@@ -109,7 +109,7 @@ open class AutoGraph {
         
         do {
             let request = try SubscriptionRequest(request: request)
-            let responseHandler = SubscriptionResponseHandler(connectionState: connectionState) { (result) in
+            let responseHandler = SubscriptionResponseHandler { (result) in
                 switch result {
                 case .success(let data):
                     self.webSocketClient?.subscriptionSerializer.serializeFinalObject(data: data, completion: completion)
@@ -117,7 +117,7 @@ open class AutoGraph {
                     completion(.failure(error))
                 }
             }
-           
+            
             return webSocketClient.subscribe(request: request, responseHandler: responseHandler)
         }
         catch let error {

--- a/AutoGraph/SubscriptionRequest.swift
+++ b/AutoGraph/SubscriptionRequest.swift
@@ -74,6 +74,7 @@ public enum GraphQLWSProtocol: String {
     case data = "data"                                 // Server -> Client
     case error = "error"                               // Server -> Client
     case complete = "complete"                         // Server -> Client
+    case unknown
     
     public func serializedSubscriptionPayload(id: String? = nil) throws -> String {
         var payload: [String : Any] = [

--- a/AutoGraph/SubscriptionRequest.swift
+++ b/AutoGraph/SubscriptionRequest.swift
@@ -74,7 +74,7 @@ public enum GraphQLWSProtocol: String {
     case data = "data"                                 // Server -> Client
     case error = "error"                               // Server -> Client
     case complete = "complete"                         // Server -> Client
-    case unknown
+    case unknownResponse                               // Server -> Client
     
     public func serializedSubscriptionPayload(id: String? = nil) throws -> String {
         var payload: [String : Any] = [

--- a/AutoGraph/SubscriptionResponseHandler.swift
+++ b/AutoGraph/SubscriptionResponseHandler.swift
@@ -2,13 +2,10 @@ import Foundation
 
 public struct SubscriptionResponseHandler {
     public typealias WebSocketCompletionBlock = (Result<Data, Error>) -> Void
-    public typealias WebSocketConnectionBlock = (WebSocketClient.State) -> Void
     
     private let completion: WebSocketCompletionBlock
-    private let connectionState: WebSocketConnectionBlock
     
-    init(connectionState: @escaping WebSocketConnectionBlock, completion: @escaping WebSocketCompletionBlock) {
-        self.connectionState = connectionState
+    init(completion: @escaping WebSocketCompletionBlock) {
         self.completion = completion
     }
     
@@ -23,9 +20,5 @@ public struct SubscriptionResponseHandler {
     
     public func didReceive(error: Error) {
         self.completion(.failure(error))
-    }
-    
-    public func didChangeConnectionState(_ state: WebSocketClient.State) {
-        self.connectionState(state)
     }
 }

--- a/AutoGraph/SubscriptionResponseHandler.swift
+++ b/AutoGraph/SubscriptionResponseHandler.swift
@@ -13,7 +13,7 @@ public struct SubscriptionResponseHandler {
         if let error = subscriptionResponse.error {
             didReceive(error: error)
         }
-        else if let data = subscriptionResponse.payload, subscriptionResponse.type == "data" {
+        else if let data = subscriptionResponse.payload, subscriptionResponse.type == .data {
             self.completion(.success(data))
         }
     }

--- a/AutoGraph/SubscriptionResponseHandler.swift
+++ b/AutoGraph/SubscriptionResponseHandler.swift
@@ -2,10 +2,13 @@ import Foundation
 
 public struct SubscriptionResponseHandler {
     public typealias WebSocketCompletionBlock = (Result<Data, Error>) -> Void
+    public typealias WebSocketConnectionBlock = (WebSocketClient.State) -> Void
     
     private let completion: WebSocketCompletionBlock
+    private let connectionState: WebSocketConnectionBlock
     
-    init(completion: @escaping WebSocketCompletionBlock) {
+    init(connectionState: @escaping WebSocketConnectionBlock, completion: @escaping WebSocketCompletionBlock) {
+        self.connectionState = connectionState
         self.completion = completion
     }
     
@@ -20,5 +23,9 @@ public struct SubscriptionResponseHandler {
     
     public func didReceive(error: Error) {
         self.completion(.failure(error))
+    }
+    
+    public func didChangeConnectionState(_ state: WebSocketClient.State) {
+        self.connectionState(state)
     }
 }

--- a/AutoGraph/SubscriptionResponseSerializer.swift
+++ b/AutoGraph/SubscriptionResponseSerializer.swift
@@ -51,13 +51,13 @@ public struct SubscriptionResponse: Decodable {
     
     let id: String
     let payload: Data?
-    let type: GraphQLWSProtocol?
+    let type: GraphQLWSProtocol
     let error: AutoGraphError?
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id  = try container.decode(String.self, forKey: .id)
-        self.type = GraphQLWSProtocol(rawValue: try container.decode(String.self, forKey: .type))
+        self.type = GraphQLWSProtocol(rawValue: try container.decode(String.self, forKey: .type)) ?? .unknown 
         let payloadContainer = try container.nestedContainer(keyedBy: PayloadCodingKeys.self, forKey: .payload)
         self.payload = try payloadContainer.decodeIfPresent(JSONValue.self, forKey: .data)?.encode()
         

--- a/AutoGraph/SubscriptionResponseSerializer.swift
+++ b/AutoGraph/SubscriptionResponseSerializer.swift
@@ -57,7 +57,7 @@ public struct SubscriptionResponse: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id  = try container.decode(String.self, forKey: .id)
-        self.type = GraphQLWSProtocol(rawValue: try container.decode(String.self, forKey: .type)) ?? .unknown 
+        self.type = GraphQLWSProtocol(rawValue: try container.decode(String.self, forKey: .type)) ?? .unknownResponse
         let payloadContainer = try container.nestedContainer(keyedBy: PayloadCodingKeys.self, forKey: .payload)
         self.payload = try payloadContainer.decodeIfPresent(JSONValue.self, forKey: .data)?.encode()
         

--- a/AutoGraph/SubscriptionResponseSerializer.swift
+++ b/AutoGraph/SubscriptionResponseSerializer.swift
@@ -51,13 +51,13 @@ public struct SubscriptionResponse: Decodable {
     
     let id: String
     let payload: Data?
-    let type: String
+    let type: GraphQLWSProtocol?
     let error: AutoGraphError?
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id  = try container.decode(String.self, forKey: .id)
-        self.type = try container.decode(String.self, forKey: .type)
+        self.type = GraphQLWSProtocol(rawValue: try container.decode(String.self, forKey: .type))
         let payloadContainer = try container.nestedContainer(keyedBy: PayloadCodingKeys.self, forKey: .payload)
         self.payload = try payloadContainer.decodeIfPresent(JSONValue.self, forKey: .data)?.encode()
         

--- a/AutoGraph/WebSocketClient.swift
+++ b/AutoGraph/WebSocketClient.swift
@@ -7,6 +7,7 @@ public typealias WebSocketConnected = (Result<Void, Error>) -> Void
 public protocol WebSocketClientDelegate: class {
     func didReceive(event: WebSocketEvent)
     func didReceive(error: Error)
+    func didChangeConnection(state: WebSocketClient.State)
 }
 
 private let kAttemptReconnectCount = 3
@@ -51,19 +52,13 @@ open class WebSocketClient {
         func makeIterator() -> Dictionary<Subscriber, SubscriptionResponseHandler>.Iterator {
             return set.makeIterator()
         }
-        
-        func didChangeConnectionState(_ state: State) {
-            self.set.forEach { (_, value: SubscriptionResponseHandler) in
-                value.didChangeConnectionState(state)
-            }
-        }
     }
     
     public var webSocket: WebSocket
     public weak var delegate: WebSocketClientDelegate?
     public private(set) var state: State = .disconnected {
         didSet {
-            self.subscriptions.forEach { $0.value.didChangeConnectionState(state) }
+            self.delegate?.didChangeConnection(state: state)
         }
     }
     

--- a/AutoGraphTests/WebSocketClientTests.swift
+++ b/AutoGraphTests/WebSocketClientTests.swift
@@ -176,7 +176,7 @@ class WebSocketClientTests: XCTestCase {
     
     func testThreeReconnectAttemptsAndDelayTimeIncreaseEachAttempt() {
         self.webSocket.enableReconnectLoop = true
-        self.subject.didReceive(event: WebSocketEvent.error(TestError()), client: self.webSocket)
+        self.subject.didReceive(event: .disconnected("", 0), client: self.webSocket)
         let delayTime1 = self.subject.reconnectTime
         guard case let .seconds(seconds) = delayTime1 else {
             XCTFail()
@@ -317,7 +317,6 @@ class MockWebSocket: Starscream.WebSocket {
     override func connect() {
         if enableReconnectLoop {
             self.isConnected = false
-            self.didReceive(event: WebSocketEvent.error(TestError()))
         }
         else {
              self.isConnected = true

--- a/AutoGraphTests/WebSocketClientTests.swift
+++ b/AutoGraphTests/WebSocketClientTests.swift
@@ -252,6 +252,7 @@ class WebSocketClientTests: XCTestCase {
 class MockWebSocketClientDelegate: WebSocketClientDelegate {
     var error: Error?
     var event: WebSocketEvent?
+    var state: AutoGraphQL.WebSocketClient.State?
     
     func didReceive(error: Error) {
         self.error = error
@@ -259,6 +260,10 @@ class MockWebSocketClientDelegate: WebSocketClientDelegate {
     
     func didReceive(event: WebSocketEvent) {
         self.event = event
+    }
+    
+    func didChangeConnection(state: AutoGraphQL.WebSocketClient.State) {
+        self.state = state
     }
 }
 


### PR DESCRIPTION
So looking at Apollo looks like when they get `connection_ack` they re send the subscription. 

```
 case .connectionAck:
        acked = true
        writeQueue()
```


So did this so we can match enums rather then strings